### PR TITLE
Use test data in Scene Delegate

### DIFF
--- a/AnyPA/SceneDelegate.swift
+++ b/AnyPA/SceneDelegate.swift
@@ -20,7 +20,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
 
         // Create the SwiftUI view that provides the window contents.
-        let contentView = ContentView()
+        let contentView = ContentView(trainStations: testData)
 
         // Use a UIHostingController as window root view controller.
         if let windowScene = scene as? UIWindowScene {


### PR DESCRIPTION
This creates the content view with test data so stations will show up in the simulator or on a device.